### PR TITLE
src: fix warn_unused_result compiler warning

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -383,8 +383,8 @@ int FileHandle::ReadStart() {
       // Use a fresh async resource.
       // Lifetime is ensured via AsyncWrap::resource_.
       Local<Object> resource = Object::New(env()->isolate());
-      resource->Set(
-          env()->context(), env()->handle_string(), read_wrap->object());
+      USE(resource->Set(
+          env()->context(), env()->handle_string(), read_wrap->object()));
       read_wrap->AsyncReset(resource);
       read_wrap->file_handle_ = this;
     } else {


### PR DESCRIPTION
../src/node_file.cc:386:7: warning: ignoring return value of
function declared with 'warn_unused_result'
attribute [-Wunused-result]

PR-URL: https://github.com/nodejs/node/pull/32241
Refs: https://github.com/nodejs/node/pull/31972
Reviewed-By: Sam Roberts <vieuxtech@gmail.com>
Reviewed-By: David Carlier <devnexen@gmail.com>
Reviewed-By: Anna Henningsen <anna@addaleax.net>
Reviewed-By: James M Snell <jasnell@gmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
